### PR TITLE
v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@
 ### Issues
 
 - Closes #11
+- Closes #12
 
-## Changed
+### Added
+
+- _get_data now has `id_override=None` so you can override `&starting_after=` as you wish
+- `id_override=0` implemented in Logs get_logs()
+
+### Changed
 
 - Changed paginaition to work without compounding to a `414`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v3.0.2
+
+### Issues
+
+- Closes #11
+
+## Changed
+
+- Changed paginaition to work without compounding to a `414`
+
 ## v3.0.1
 
 ### Issues
@@ -8,7 +18,7 @@
 
 ## Changed
 
-- Changed paginaition to work, now returns ibj not response 
+- Changed paginaition to work, now returns obj not response
 - good catch @bryanheinz
 
 ## v3.0.0

--- a/SimpleMDMpy/Logs.py
+++ b/SimpleMDMpy/Logs.py
@@ -11,8 +11,8 @@ class Logs(SimpleMDMpy.SimpleMDM.Connection):
         SimpleMDMpy.SimpleMDM.Connection.__init__(self, api_key)
         self.url = self._url("/logs")
 
-    def get_logs(self):
-        """And I mean all the LOGS, before pagination"""
+    def get_logs(self, id_override=0):
+        """And I mean all the LOGS"""
         url = self.url
         data = {}
-        return self._get_data(url, data)
+        return self._get_data(url, data, id_override=id_override)

--- a/SimpleMDMpy/SimpleMDM.py
+++ b/SimpleMDMpy/SimpleMDM.py
@@ -30,8 +30,8 @@ class Connection(object): #pylint: disable=old-style-class,too-few-public-method
         has_more = True
         resp_data = []
         while has_more:
-            url = url + "?limit=20&starting_after=" + str(id)
-            resp = requests.get(url, data, auth=(self.api_key, ""), proxies=self.proxyDict)
+            filteredUrl = url + "?limit=20&starting_after=" + str(id)
+            resp = requests.get(filteredUrl, data, auth=(self.api_key, ""), proxies=self.proxyDict)
             resp_json = resp.json()
             if not resp.status_code in range(200, 207):
                 break

--- a/SimpleMDMpy/SimpleMDM.py
+++ b/SimpleMDMpy/SimpleMDM.py
@@ -24,9 +24,9 @@ class Connection(object): #pylint: disable=old-style-class,too-few-public-method
         """base api url"""
         return 'https://a.simplemdm.com/api/v1' + path
 
-    def _get_data(self, url, data=None):
+    def _get_data(self, url, data=None, id_override=None):
         """GET call to SimpleMDM API"""
-        id = 0 #pylint: disable=invalid-name,redefined-builtin
+        id = id_override #pylint: disable=invalid-name,redefined-builtin
         has_more = True
         resp_data = []
         while has_more:
@@ -36,7 +36,7 @@ class Connection(object): #pylint: disable=old-style-class,too-few-public-method
             if not resp.status_code in range(200, 207):
                 break
             has_more = resp_json.get('has_more', None)
-            if has_more is None:
+            if has_more is None or resp_json['data'] == []:
                 resp_data = resp_json['data']
                 break
             else:


### PR DESCRIPTION
### Issues

- Closes #11
- Closes #12

### Added

- _get_data now has `id_override=None` so you can override `&starting_after=` as you wish
- `id_override=0` implemented in Logs get_logs()