### PR TITLE
Add basic pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "simpleMDMpy"
+description = "python lib for simpleMDM API"
+version = "3.0.7"
+authors = [
+    { name = "SteveKueng", email = "steve.kueng@srgssr.ch" }
+]
+dependencies = [
+    "requests"
+]
+


### PR DESCRIPTION
This allows installation of the lib via requirements.txt (pip refuses to install if there is no setup.py or pyproject.toml).