### PR TITLE
fix: include_awaiting_enrollment

### DIFF
--- a/SimpleMDMpy/Devices.py
+++ b/SimpleMDMpy/Devices.py
@@ -30,7 +30,9 @@ class Devices(SimpleMDMpy.SimpleMDM.Connection):
             array: An array of dictionary objects with device information.
         """
         url = self.url
-        params = {'include_awaiting_enrollment': include_awaiting_enrollment}
+        params = {}
+        if include_awaiting_enrollment:
+            params['include_awaiting_enrollment'] = True
         # if a device ID is specified, then ignore any searches
         if device_id != 'all':
             url = url + "/" + str(device_id)


### PR DESCRIPTION
The SimpleMDM documentation is wrong or misleading for these parameters. When including `include_awaiting_enrollment` key with any value (or no value), it will determine the value to be true.

I believe that this may have been a change with SimpleMDM, but I cannot verify that.